### PR TITLE
Add interest level filtering to Kanban board columns

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
 import { Briefcase, Plus } from "lucide-react";
@@ -13,6 +13,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 
@@ -35,10 +42,18 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<string>("All");
+
+  const filteredProspects = interestFilter === "All"
+    ? prospects
+    : prospects.filter((p) => p.interestLevel === interestFilter);
+
+  const statusSlug = status.replace(/\s+/g, "-").toLowerCase();
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
-      data-testid={`column-${status.replace(/\s+/g, "-").toLowerCase()}`}
+      data-testid={`column-${statusSlug}`}
     >
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
         <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
@@ -46,10 +61,32 @@ function KanbanColumn({
         <Badge
           variant="secondary"
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          data-testid={`badge-count-${statusSlug}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
+      </div>
+      <div className="px-2 pt-2">
+        <Select value={interestFilter} onValueChange={setInterestFilter}>
+          <SelectTrigger
+            className="h-7 text-xs w-full"
+            data-testid={`filter-interest-${statusSlug}`}
+          >
+            <SelectValue placeholder="Filter by interest" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="All" data-testid={`filter-option-all-${statusSlug}`}>All</SelectItem>
+            {INTEREST_LEVELS.map((level) => (
+              <SelectItem
+                key={level}
+                value={level}
+                data-testid={`filter-option-${level.toLowerCase()}-${statusSlug}`}
+              >
+                {level}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
@@ -58,12 +95,12 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
+          ) : filteredProspects.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${statusSlug}`}>
               <p className="text-xs text-muted-foreground">No prospects</p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}


### PR DESCRIPTION
Integrates a client-side filtering mechanism into the Kanban board's `home.tsx` component. This adds a `Select` dropdown to each `KanbanColumn` to filter job cards by `interestLevel` (Low, Medium, High, All) independently per column. The `INTEREST_LEVELS` constant is imported, local state `interestFilter` is managed within `KanbanColumn`, and `filteredProspects` are rendered based on the selected filter.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: d72828b2-fc94-4cc2-b5f3-29d512fe2ba4
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 2c6f8560-8f7b-4115-9cd9-a71a7ab4ef75
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/782b3197-6ee1-4768-a762-d654da9879b8/d72828b2-fc94-4cc2-b5f3-29d512fe2ba4/aZ7NfSw
Replit-Helium-Checkpoint-Created: true