### PR TITLE
Add target salary field to job tracker with inline editing

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -37,6 +37,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       notes: "",
+      targetSalary: null,
     },
   });
 
@@ -156,6 +157,34 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="targetSalary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                  <Input
+                    type="text"
+                    inputMode="numeric"
+                    placeholder="e.g. 150000"
+                    className="pl-7"
+                    data-testid="input-target-salary"
+                    value={field.value != null ? String(field.value) : ""}
+                    onChange={(e) => {
+                      const raw = e.target.value.replace(/[^0-9]/g, "");
+                      field.onChange(raw === "" ? null : parseInt(raw, 10));
+                    }}
+                  />
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -42,6 +42,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       notes: prospect.notes ?? "",
+      targetSalary: prospect.targetSalary ?? null,
     },
   });
 
@@ -160,6 +161,34 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="targetSalary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                  <Input
+                    type="text"
+                    inputMode="numeric"
+                    placeholder="e.g. 150000"
+                    className="pl-7"
+                    data-testid="input-edit-target-salary"
+                    value={field.value != null ? String(field.value) : ""}
+                    onChange={(e) => {
+                      const raw = e.target.value.replace(/[^0-9]/g, "");
+                      field.onChange(raw === "" ? null : parseInt(raw, 10));
+                    }}
+                  />
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -12,6 +13,95 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { EditProspectForm } from "./edit-prospect-form";
+
+function formatCurrency(value: number): string {
+  return `$${value.toLocaleString("en-US")}`;
+}
+
+function InlineSalaryEditor({ prospect }: { prospect: Prospect }) {
+  const { toast } = useToast();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(prospect.targetSalary != null ? String(prospect.targetSalary) : "");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const savedRef = useRef(false);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+      savedRef.current = false;
+    }
+  }, [editing]);
+
+  const mutation = useMutation({
+    mutationFn: async (salary: number | null) => {
+      await apiRequest("PATCH", `/api/prospects/${prospect.id}`, { targetSalary: salary });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prospects"] });
+      setEditing(false);
+    },
+    onError: () => {
+      toast({ title: "Failed to update salary", variant: "destructive" });
+    },
+  });
+
+  const handleSave = () => {
+    if (savedRef.current || mutation.isPending) return;
+    savedRef.current = true;
+    const raw = value.replace(/[^0-9]/g, "");
+    const salary = raw === "" ? null : parseInt(raw, 10);
+    if (salary !== null && salary < 0) return;
+    mutation.mutate(salary);
+  };
+
+  if (editing) {
+    return (
+      <div
+        className="relative"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground text-xs">$</span>
+        <Input
+          ref={inputRef}
+          type="text"
+          inputMode="numeric"
+          className="h-6 text-xs pl-5 pr-2 w-28"
+          data-testid={`input-inline-salary-${prospect.id}`}
+          value={value}
+          onChange={(e) => {
+            const raw = e.target.value.replace(/[^0-9]/g, "");
+            setValue(raw);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.currentTarget.blur();
+            }
+            if (e.key === "Escape") setEditing(false);
+          }}
+          onBlur={handleSave}
+        />
+      </div>
+    );
+  }
+
+  if (prospect.targetSalary == null) return null;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400 cursor-pointer hover:underline"
+      onClick={(e) => {
+        e.stopPropagation();
+        setValue(String(prospect.targetSalary ?? ""));
+        setEditing(true);
+      }}
+      data-testid={`text-salary-${prospect.id}`}
+    >
+      <DollarSign className="w-3 h-3" />
+      {formatCurrency(prospect.targetSalary)}
+    </span>
+  );
+}
 
 function InterestIndicator({ level }: { level: string }) {
   switch (level) {
@@ -105,6 +195,7 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          <InlineSalaryEditor prospect={prospect} />
         </div>
 
         {prospect.jobUrl && (

--- a/replit.md
+++ b/replit.md
@@ -22,7 +22,7 @@ client/src/
   App.tsx                     - Root component, routing, providers
   pages/home.tsx              - Kanban board with 7 status columns
   components/
-    prospect-card.tsx         - Card component with edit/delete actions
+    prospect-card.tsx         - Card component with edit/delete actions and inline salary editing
     add-prospect-form.tsx     - Dialog form for creating prospects
     edit-prospect-form.tsx    - Dialog form for editing prospects
     ui/                       - shadcn/ui primitives
@@ -30,7 +30,7 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, target_salary (nullable integer), created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -21,3 +21,81 @@ describe("prospect creation validation", () => {
     expect(result.errors).toContain("Role title is required");
   });
 });
+
+describe("target salary validation", () => {
+  test("rejects a negative salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      targetSalary: -50000,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Target salary cannot be negative");
+  });
+
+  test("rejects non-numeric salary input", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      targetSalary: "not-a-number",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Target salary must be a number");
+  });
+
+  test("accepts a blank (null) salary since it is optional", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      targetSalary: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a blank (undefined) salary since it is optional", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a valid positive whole number salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      targetSalary: 150000,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts zero salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      targetSalary: 0,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects a decimal salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      targetSalary: 150000.50,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Target salary must be a whole number");
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,17 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.targetSalary !== undefined && data.targetSalary !== null) {
+    const salary = Number(data.targetSalary);
+    if (isNaN(salary) || !Number.isFinite(salary)) {
+      errors.push("Target salary must be a number");
+    } else if (!Number.isInteger(salary)) {
+      errors.push("Target salary must be a whole number");
+    } else if (salary < 0) {
+      errors.push("Target salary cannot be negative");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -40,6 +40,16 @@ export async function registerRoutes(
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
 
+    if (body.targetSalary !== undefined) {
+      if (body.targetSalary === null) {
+        updates.targetSalary = null;
+      } else if (typeof body.targetSalary !== "number" || !Number.isInteger(body.targetSalary) || body.targetSalary < 0) {
+        return res.status(400).json({ message: "Target salary must be a non-negative whole number" });
+      } else {
+        updates.targetSalary = body.targetSalary;
+      }
+    }
+
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {
         return res.status(400).json({ message: `Status must be one of: ${STATUSES.join(", ")}` });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -22,6 +22,7 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
+  targetSalary: integer("target_salary"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -35,6 +36,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
+  targetSalary: z.number().int("Salary must be a whole number").min(0, "Salary cannot be negative").optional().nullable(),
 });
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;


### PR DESCRIPTION
Introduces a new `targetSalary` field to the prospect schema, forms, and card component, enabling users to input, display, and edit salary information with validation and formatting.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: d72828b2-fc94-4cc2-b5f3-29d512fe2ba4
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 21869cc6-741e-4bc1-8804-c345405635b0
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/782b3197-6ee1-4768-a762-d654da9879b8/d72828b2-fc94-4cc2-b5f3-29d512fe2ba4/icTdQsi
Replit-Helium-Checkpoint-Created: true