### PR TITLE
Add a feature for users to save and edit notes on job cards

### DIFF
--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -2,7 +2,8 @@ import { useState, useRef, useEffect } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign, StickyNote } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -131,6 +132,88 @@ function InterestIndicator({ level }: { level: string }) {
   }
 }
 
+function NotesModal({ prospect }: { prospect: Prospect }) {
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(prospect.notes ?? "");
+
+  useEffect(() => {
+    if (open) {
+      setDraft(prospect.notes ?? "");
+    }
+  }, [open, prospect.notes]);
+
+  const mutation = useMutation({
+    mutationFn: async (notes: string | null) => {
+      await apiRequest("PATCH", `/api/prospects/${prospect.id}`, { notes });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prospects"] });
+      setOpen(false);
+    },
+    onError: () => {
+      toast({ title: "Failed to save notes", variant: "destructive" });
+    },
+  });
+
+  const hasNotes = !!prospect.notes;
+
+  return (
+    <>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-6 w-6"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        data-testid={`button-notes-${prospect.id}`}
+      >
+        <StickyNote
+          className={`w-3.5 h-3.5 ${hasNotes ? "text-amber-500" : "text-muted-foreground/40"}`}
+        />
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md" onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>Notes — {prospect.companyName}</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Add notes about this opportunity…"
+            className="min-h-[120px]"
+            data-testid={`textarea-notes-${prospect.id}`}
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setOpen(false)}
+              data-testid={`button-notes-cancel-${prospect.id}`}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              disabled={mutation.isPending}
+              onClick={() => {
+                const value = draft.trim() === "" ? null : draft;
+                mutation.mutate(value);
+              }}
+              data-testid={`button-notes-save-${prospect.id}`}
+            >
+              {mutation.isPending ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
 export function ProspectCard({ prospect }: { prospect: Prospect }) {
   const { toast } = useToast();
   const [editOpen, setEditOpen] = useState(false);
@@ -196,6 +279,7 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
           <InlineSalaryEditor prospect={prospect} />
+          <NotesModal prospect={prospect} />
         </div>
 
         {prospect.jobUrl && (
@@ -212,11 +296,6 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
           </a>
         )}
 
-        {prospect.notes && (
-          <p className="text-xs text-muted-foreground line-clamp-2" data-testid={`text-notes-${prospect.id}`}>
-            {prospect.notes}
-          </p>
-        )}
       </div>
 
       <Dialog open={editOpen} onOpenChange={setEditOpen}>

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -99,3 +99,70 @@ describe("target salary validation", () => {
     expect(result.errors).toContain("Target salary must be a whole number");
   });
 });
+
+describe("notes validation", () => {
+  test("accepts notes as a valid string", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      notes: "Had a great phone screen",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("allows updating notes to a new string value", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      notes: "Updated: second interview scheduled",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts null notes (clearing notes)", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      notes: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts undefined notes (field not provided)", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts an empty string for notes", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      notes: "",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects non-string notes", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      notes: 12345,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Notes must be a string");
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,12 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.notes !== undefined && data.notes !== null) {
+    if (typeof data.notes !== "string") {
+      errors.push("Notes must be a string");
+    }
+  }
+
   if (data.targetSalary !== undefined && data.targetSalary !== null) {
     const salary = Number(data.targetSalary);
     if (isNaN(salary) || !Number.isFinite(salary)) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -38,7 +38,12 @@ export async function registerRoutes(
     if (body.companyName !== undefined) updates.companyName = body.companyName;
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
-    if (body.notes !== undefined) updates.notes = body.notes;
+    if (body.notes !== undefined) {
+      if (body.notes !== null && typeof body.notes !== "string") {
+        return res.status(400).json({ message: "Notes must be a string or null" });
+      }
+      updates.notes = body.notes;
+    }
 
     if (body.targetSalary !== undefined) {
       if (body.targetSalary === null) {


### PR DESCRIPTION
Implement a Notes feature with a modal for saving/editing text notes. Update client-side components and server-side validation to handle notes, including type validation and persistence. Add comprehensive unit tests for the new notes functionality.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: d72828b2-fc94-4cc2-b5f3-29d512fe2ba4
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: ba203dab-eb50-4513-902f-c799cb11e658
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/782b3197-6ee1-4768-a762-d654da9879b8/d72828b2-fc94-4cc2-b5f3-29d512fe2ba4/XZLYmSm
Replit-Helium-Checkpoint-Created: true